### PR TITLE
Add support for latest RN builds

### DIFF
--- a/ios/RNJapaneseTokenizer.h
+++ b/ios/RNJapaneseTokenizer.h
@@ -1,9 +1,4 @@
-
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 #import <Foundation/Foundation.h>
 


### PR DESCRIPTION
The latest versions of RN dropped support for double quote imports entirely.

As a result, the conditional compile in the header file causes iOS builds to fail entirely on the latest versions of RN.

Removing the older double-quote import fixes it, but also means that the tokenizer will now no longer work on really, really old versions of RN.